### PR TITLE
Add Things MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple FastMCP Server
 
-A minimal FastMCP server with a single echo tool.
+A minimal FastMCP server with tools for working with the Things 3 task manager.
 
 ## Usage
 
@@ -74,6 +74,289 @@ Example response:
 {
   "output": {
     "echo": "Hello, world!"
+  }
+}
+```
+
+### Things 3 Task Management Tools
+
+These tools allow interaction with the Things 3 task manager application on macOS/iOS. They require access to the Things 3 SQLite database.
+
+#### get_tasks
+
+Retrieve tasks with flexible filtering options.
+
+Example request:
+```json
+{
+  "tool": "get_tasks",
+  "input": {
+    "status": "upcoming",
+    "tag": "work",
+    "limit": 10
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "tasks": [
+      {
+        "uuid": "task-uuid-1",
+        "title": "Finish project report",
+        "status": "upcoming",
+        "tags": ["work"]
+      },
+      ...
+    ]
+  }
+}
+```
+
+Available filters:
+- `status`: Filter by task status ("upcoming", "completed", "canceled", "trash")
+- `tag`: Filter by tag name
+- `search`: Text search across task titles
+- `area`: Filter by area name
+- `project`: Filter by project title
+- `heading`: Filter by task heading
+- `limit`: Maximum number of tasks to return
+
+#### get_task_detail
+
+Get detailed information about a specific task.
+
+Example request:
+```json
+{
+  "tool": "get_task_detail",
+  "input": {
+    "uuid": "task-uuid-1"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "task": {
+      "uuid": "task-uuid-1",
+      "title": "Finish project report",
+      "notes": "Include Q3 metrics in the analysis",
+      "status": "upcoming",
+      "tags": ["work", "reports"],
+      "checklist": [
+        "Add executive summary",
+        "Include Q3 metrics",
+        "Add recommendations"
+      ]
+    }
+  }
+}
+```
+
+#### get_projects
+
+Retrieve projects with filtering options.
+
+Example request:
+```json
+{
+  "tool": "get_projects",
+  "input": {
+    "status": "upcoming",
+    "area": "Work"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "projects": [
+      {
+        "uuid": "project-uuid-1",
+        "title": "Q3 Planning",
+        "status": "upcoming",
+        "area": "Work"
+      },
+      ...
+    ]
+  }
+}
+```
+
+#### get_areas
+
+List organizational areas.
+
+Example request:
+```json
+{
+  "tool": "get_areas",
+  "input": {
+    "search": "Work"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "areas": [
+      {
+        "uuid": "area-uuid-1",
+        "title": "Work"
+      },
+      ...
+    ]
+  }
+}
+```
+
+#### get_tags
+
+List all available tags.
+
+Example request:
+```json
+{
+  "tool": "get_tags",
+  "input": {}
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "tags": [
+      {
+        "uuid": "tag-uuid-1",
+        "title": "work"
+      },
+      {
+        "uuid": "tag-uuid-2",
+        "title": "personal"
+      },
+      ...
+    ]
+  }
+}
+```
+
+#### create_task
+
+Create a new task with optional metadata.
+
+Example request:
+```json
+{
+  "tool": "create_task",
+  "input": {
+    "title": "Write quarterly report",
+    "notes": "Include metrics from Q3",
+    "tags": ["work", "reports"],
+    "when": "today",
+    "deadline": "2025-06-30",
+    "checklist": [
+      "Gather data",
+      "Create draft",
+      "Review with team"
+    ],
+    "project": "Quarterly Planning"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "uuid": "new-task-uuid",
+    "title": "Write quarterly report"
+  }
+}
+```
+
+#### complete_task
+
+Mark a task as completed.
+
+Example request:
+```json
+{
+  "tool": "complete_task",
+  "input": {
+    "uuid": "task-uuid-1"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "success": true,
+    "uuid": "task-uuid-1"
+  }
+}
+```
+
+#### cancel_task
+
+Mark a task as canceled.
+
+Example request:
+```json
+{
+  "tool": "cancel_task",
+  "input": {
+    "uuid": "task-uuid-1"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "success": true,
+    "uuid": "task-uuid-1"
+  }
+}
+```
+
+#### update_task
+
+Update an existing task's attributes.
+
+Example request:
+```json
+{
+  "tool": "update_task",
+  "input": {
+    "uuid": "task-uuid-1",
+    "title": "Updated task title",
+    "notes": "Updated notes content",
+    "tags": ["updated-tag"],
+    "when": "tomorrow",
+    "deadline": "2025-07-15"
+  }
+}
+```
+
+Example response:
+```json
+{
+  "output": {
+    "success": true,
+    "uuid": "task-uuid-1"
   }
 }
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.109.0
 uvicorn>=0.27.0
 pydantic>=2.5.2
 httpx>=0.28.0
+things.py>=0.9.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from typing import Dict, Any
+from pydantic import BaseModel, Field
+from typing import Dict, Any, List, Optional
+import things
 
 app = FastAPI()
 
@@ -10,6 +11,88 @@ class EchoInput(BaseModel):
 class EchoOutput(BaseModel):
     echo: str
 
+class GetTasksInput(BaseModel):
+    status: Optional[str] = Field(None, description="Filter by status: 'upcoming', 'completed', 'canceled', 'trash'")
+    tag: Optional[str] = Field(None, description="Filter by tag name")
+    search: Optional[str] = Field(None, description="Search term to filter tasks")
+    area: Optional[str] = Field(None, description="Filter by area name")
+    project: Optional[str] = Field(None, description="Filter by project title")
+    heading: Optional[str] = Field(None, description="Filter by heading")
+    limit: Optional[int] = Field(None, description="Limit the number of results")
+
+class GetTasksOutput(BaseModel):
+    tasks: List[Dict[str, Any]]
+
+class GetTaskDetailInput(BaseModel):
+    uuid: str = Field(..., description="UUID of the task to retrieve")
+
+class GetTaskDetailOutput(BaseModel):
+    task: Dict[str, Any]
+
+class GetProjectsInput(BaseModel):
+    status: Optional[str] = Field(None, description="Filter by status: 'upcoming', 'completed', 'canceled', 'trash'")
+    tag: Optional[str] = Field(None, description="Filter by tag name")
+    search: Optional[str] = Field(None, description="Search term to filter projects")
+    area: Optional[str] = Field(None, description="Filter by area name")
+    limit: Optional[int] = Field(None, description="Limit the number of results")
+
+class GetProjectsOutput(BaseModel):
+    projects: List[Dict[str, Any]]
+
+class GetAreasInput(BaseModel):
+    search: Optional[str] = Field(None, description="Search term to filter areas")
+
+class GetAreasOutput(BaseModel):
+    areas: List[Dict[str, Any]]
+
+class GetTagsInput(BaseModel):
+    search: Optional[str] = Field(None, description="Search term to filter tags")
+
+class GetTagsOutput(BaseModel):
+    tags: List[Dict[str, Any]]
+
+class CreateTaskInput(BaseModel):
+    title: str = Field(..., description="Task title")
+    notes: Optional[str] = Field(None, description="Task notes")
+    tags: Optional[List[str]] = Field(None, description="List of tag names to assign")
+    when: Optional[str] = Field(None, description="When to start the task (today, tomorrow, evening, etc.)")
+    deadline: Optional[str] = Field(None, description="Deadline date (YYYY-MM-DD)")
+    checklist: Optional[List[str]] = Field(None, description="Checklist items")
+    project: Optional[str] = Field(None, description="Title of the project to add the task to")
+    area: Optional[str] = Field(None, description="Title of the area to add the task to")
+    heading: Optional[str] = Field(None, description="Heading under which to add this task")
+
+class CreateTaskOutput(BaseModel):
+    uuid: str
+    title: str
+
+class CompleteTaskInput(BaseModel):
+    uuid: str = Field(..., description="UUID of the task to complete")
+
+class CompleteTaskOutput(BaseModel):
+    success: bool
+    uuid: str
+
+class CancelTaskInput(BaseModel):
+    uuid: str = Field(..., description="UUID of the task to cancel")
+
+class CancelTaskOutput(BaseModel):
+    success: bool
+    uuid: str
+
+class UpdateTaskInput(BaseModel):
+    uuid: str = Field(..., description="UUID of the task to update")
+    title: Optional[str] = Field(None, description="New task title")
+    notes: Optional[str] = Field(None, description="New task notes")
+    tags: Optional[List[str]] = Field(None, description="New list of tag names to assign")
+    when: Optional[str] = Field(None, description="New when date (today, tomorrow, evening, etc.)")
+    deadline: Optional[str] = Field(None, description="New deadline date (YYYY-MM-DD)")
+    checklist: Optional[List[str]] = Field(None, description="New checklist items")
+
+class UpdateTaskOutput(BaseModel):
+    success: bool
+    uuid: str
+
 @app.get("/")
 async def root():
     return {"message": "Simple FastMCP Server"}
@@ -18,15 +101,82 @@ async def root():
 async def handle_mcp(body: Dict[str, Any]):
     try:
         tool_name = body.get("tool")
-        
-        # Check for invalid tool first
-        if tool_name != "echo":
-            raise HTTPException(status_code=404, detail=f"Tool {tool_name} not found")
-        
         input_data = body.get("input", {})
-        validated_input = EchoInput(**input_data)
-        result = EchoOutput(echo=validated_input.message)
-        return {"output": result.model_dump()}
+        
+        if tool_name == "echo":
+            validated_input = EchoInput(**input_data)
+            result = EchoOutput(echo=validated_input.message)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "get_tasks":
+            validated_input = GetTasksInput(**input_data)
+            kwargs = {k: v for k, v in validated_input.model_dump().items() if v is not None}
+            tasks = things.tasks(**kwargs)
+            result = GetTasksOutput(tasks=tasks)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "get_task_detail":
+            validated_input = GetTaskDetailInput(**input_data)
+            task = things.get(validated_input.uuid)
+            if not task:
+                raise HTTPException(status_code=404, detail=f"Task with UUID {validated_input.uuid} not found")
+            result = GetTaskDetailOutput(task=task)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "get_projects":
+            validated_input = GetProjectsInput(**input_data)
+            kwargs = {k: v for k, v in validated_input.model_dump().items() if v is not None}
+            projects = things.projects(**kwargs)
+            result = GetProjectsOutput(projects=projects)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "get_areas":
+            validated_input = GetAreasInput(**input_data)
+            kwargs = {k: v for k, v in validated_input.model_dump().items() if v is not None}
+            areas = things.areas(**kwargs)
+            result = GetAreasOutput(areas=areas)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "get_tags":
+            validated_input = GetTagsInput(**input_data)
+            kwargs = {k: v for k, v in validated_input.model_dump().items() if v is not None}
+            tags = things.tags(**kwargs)
+            result = GetTagsOutput(tags=tags)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "create_task":
+            validated_input = CreateTaskInput(**input_data)
+            kwargs = {k: v for k, v in validated_input.model_dump().items() if v is not None}
+            uuid = things.create_todo(**kwargs)
+            result = CreateTaskOutput(uuid=uuid, title=validated_input.title)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "complete_task":
+            validated_input = CompleteTaskInput(**input_data)
+            success = things.complete(validated_input.uuid)
+            result = CompleteTaskOutput(success=success, uuid=validated_input.uuid)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "cancel_task":
+            validated_input = CancelTaskInput(**input_data)
+            success = things.cancel(validated_input.uuid)
+            result = CancelTaskOutput(success=success, uuid=validated_input.uuid)
+            return {"output": result.model_dump()}
+        
+        elif tool_name == "update_task":
+            validated_input = UpdateTaskInput(**input_data)
+            uuid = validated_input.uuid
+            kwargs = {k: v for k, v in validated_input.model_dump().items() if k != "uuid" and v is not None}
+            
+            if not kwargs:
+                raise HTTPException(status_code=400, detail="No update parameters provided")
+            
+            success = things.update(uuid, **kwargs)
+            result = UpdateTaskOutput(success=success, uuid=uuid)
+            return {"output": result.model_dump()}
+        
+        else:
+            raise HTTPException(status_code=404, detail=f"Tool {tool_name} not found")
         
     except HTTPException:
         # Re-raise HTTP exceptions

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
 from main import app
 
 client = TestClient(app)
@@ -35,3 +36,259 @@ def test_invalid_tool():
         }
     )
     assert response.status_code == 404
+
+@patch('things.tasks')
+def test_get_tasks(mock_tasks):
+    # Mock data
+    mock_tasks.return_value = [
+        {"uuid": "1234", "title": "Test Task", "status": "upcoming"}
+    ]
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "get_tasks",
+            "input": {
+                "status": "upcoming",
+                "limit": 10
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "tasks": [{"uuid": "1234", "title": "Test Task", "status": "upcoming"}]
+        }
+    }
+    mock_tasks.assert_called_once_with(status="upcoming", limit=10)
+
+@patch('things.get')
+def test_get_task_detail(mock_get):
+    # Mock data
+    task_uuid = "test-uuid"
+    mock_get.return_value = {
+        "uuid": task_uuid,
+        "title": "Task Detail",
+        "notes": "Task notes"
+    }
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "get_task_detail",
+            "input": {
+                "uuid": task_uuid
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "task": {
+                "uuid": task_uuid,
+                "title": "Task Detail",
+                "notes": "Task notes"
+            }
+        }
+    }
+    mock_get.assert_called_once_with(task_uuid)
+
+@patch('things.get')
+def test_get_task_detail_not_found(mock_get):
+    # Task not found
+    mock_get.return_value = None
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "get_task_detail",
+            "input": {
+                "uuid": "nonexistent-uuid"
+            }
+        }
+    )
+    assert response.status_code == 404
+
+@patch('things.projects')
+def test_get_projects(mock_projects):
+    # Mock data
+    mock_projects.return_value = [
+        {"uuid": "proj-1", "title": "Test Project", "status": "upcoming"}
+    ]
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "get_projects",
+            "input": {
+                "status": "upcoming"
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "projects": [{"uuid": "proj-1", "title": "Test Project", "status": "upcoming"}]
+        }
+    }
+    mock_projects.assert_called_once_with(status="upcoming")
+
+@patch('things.areas')
+def test_get_areas(mock_areas):
+    # Mock data
+    mock_areas.return_value = [
+        {"uuid": "area-1", "title": "Test Area"}
+    ]
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "get_areas",
+            "input": {
+                "search": "Test"
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "areas": [{"uuid": "area-1", "title": "Test Area"}]
+        }
+    }
+    mock_areas.assert_called_once_with(search="Test")
+
+@patch('things.tags')
+def test_get_tags(mock_tags):
+    # Mock data
+    mock_tags.return_value = [
+        {"uuid": "tag-1", "title": "TestTag"}
+    ]
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "get_tags",
+            "input": {}
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "tags": [{"uuid": "tag-1", "title": "TestTag"}]
+        }
+    }
+    mock_tags.assert_called_once_with()
+
+@patch('things.create_todo')
+def test_create_task(mock_create_todo):
+    # Mock data
+    task_uuid = "new-task-uuid"
+    mock_create_todo.return_value = task_uuid
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "create_task",
+            "input": {
+                "title": "New Task",
+                "notes": "Task notes",
+                "when": "today"
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "uuid": task_uuid,
+            "title": "New Task"
+        }
+    }
+    mock_create_todo.assert_called_once_with(title="New Task", notes="Task notes", when="today")
+
+@patch('things.complete')
+def test_complete_task(mock_complete):
+    # Mock data
+    task_uuid = "task-to-complete"
+    mock_complete.return_value = True
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "complete_task",
+            "input": {
+                "uuid": task_uuid
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "success": True,
+            "uuid": task_uuid
+        }
+    }
+    mock_complete.assert_called_once_with(task_uuid)
+
+@patch('things.cancel')
+def test_cancel_task(mock_cancel):
+    # Mock data
+    task_uuid = "task-to-cancel"
+    mock_cancel.return_value = True
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "cancel_task",
+            "input": {
+                "uuid": task_uuid
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "success": True,
+            "uuid": task_uuid
+        }
+    }
+    mock_cancel.assert_called_once_with(task_uuid)
+
+@patch('things.update')
+def test_update_task(mock_update):
+    # Mock data
+    task_uuid = "task-to-update"
+    mock_update.return_value = True
+    
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "update_task",
+            "input": {
+                "uuid": task_uuid,
+                "title": "Updated Title",
+                "notes": "Updated notes"
+            }
+        }
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "output": {
+            "success": True,
+            "uuid": task_uuid
+        }
+    }
+    mock_update.assert_called_once_with(task_uuid, title="Updated Title", notes="Updated notes")
+
+def test_update_task_no_params():
+    response = client.post(
+        "/mcp",
+        json={
+            "tool": "update_task",
+            "input": {
+                "uuid": "some-uuid"
+                # No other parameters provided
+            }
+        }
+    )
+    assert response.status_code == 400
+    assert "No update parameters provided" in response.json()["detail"]


### PR DESCRIPTION
This PR adds MCP tools based on the Things.py library, providing integration with the Things 3 task manager.

## Added Features

- Added things.py library dependency
- Implemented 9 MCP tools for Things 3 integration:
  - get_tasks: List tasks with filtering
  - get_task_detail: Get detailed task information
  - get_projects: List projects
  - get_areas: List organizational areas
  - get_tags: List all tags
  - create_task: Create new tasks
  - complete_task: Mark tasks as done
  - cancel_task: Cancel tasks
  - update_task: Modify existing tasks
- Added comprehensive tests with mocking
- Updated README with tool documentation and examples

## Notes

- The implementation uses the things.py library which interfaces with the Things 3 SQLite database
- The Things 3 app is macOS/iOS only

Fixes #1

Generated with [Claude Code](https://claude.ai/code)